### PR TITLE
Remove unused db seed config

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -47,7 +47,6 @@ max_client_conn = 100
 enabled = true
 # Specifies an ordered list of seed files to load during db reset.
 # Supports glob patterns relative to supabase directory: './seeds/*.sql'
-sql_paths = ['./seed.sql']
 
 [realtime]
 enabled = true


### PR DESCRIPTION
## Summary
- remove db.seed.sql_paths from Supabase config

## Testing
- `npm run typecheck`
