### PR TITLE
Fix ts-node script import path

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "refresh-news": "ts-node scripts/refresh-news.ts",
-    "test-scoring": "ts-node scripts/test-scoring.ts",
+    "test-scoring": "ts-node --compiler-options '{\"module\":\"CommonJS\",\"allowImportingTsExtensions\":true}' scripts/test-scoring.ts",
     "precommit": "npm run typecheck",
     "prepare": "husky"
   },

--- a/scripts/test-scoring.ts
+++ b/scripts/test-scoring.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { ArticleService } from '../src/lib/services/articleService.js';
+import { ArticleService } from '../src/lib/services/articleService.ts';
 
 async function testScoring() {
   const articleService = new ArticleService();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "allowImportingTsExtensions": true,
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Summary
- import the `ArticleService` `.ts` file in `scripts/test-scoring.ts`
- allow importing TS extensions via `tsconfig.json`
- update the `test-scoring` npm script for ts-node

## Testing
- `npm run typecheck`
- `npm run test-scoring` *(fails: Missing required environment variables)*