### PR TITLE
Filter news by time window

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -3,4 +3,5 @@ import '@testing-library/jest-dom';
 // Mock environment variables
 process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost:54321';
 process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'your-anon-key';
-process.env.PRODUCT_HUNT_TOKEN = 'your-ph-token'; 
+process.env.PRODUCT_HUNT_TOKEN = 'your-ph-token';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'your-service-role-key';

--- a/src/lib/config/env.ts
+++ b/src/lib/config/env.ts
@@ -28,6 +28,7 @@ export function validateEnv() {
       url: process.env.NEXT_PUBLIC_SUPABASE_URL as string,
       anonKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
       serviceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY as string
-    }
+    },
+    newsLookbackHours: Number(process.env.NEWS_LOOKBACK_HOURS || '24')
   };
 }

--- a/src/lib/news/fetcher.test.ts
+++ b/src/lib/news/fetcher.test.ts
@@ -1,0 +1,66 @@
+import { getLatestNews } from './fetcher';
+import { createClient } from '@supabase/supabase-js';
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(),
+}));
+
+describe('getLatestNews', () => {
+  it('returns only articles published within the lookback window', async () => {
+    const now = new Date('2024-01-02T00:00:00Z').getTime();
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+    process.env.NEWS_LOOKBACK_HOURS = '24';
+
+    const articles = [
+      {
+        id: '1',
+        title: 'Recent',
+        url: 'http://a',
+        source: 'test',
+        published_date: new Date(now - 60 * 60 * 1000).toISOString(),
+        language: 'en',
+        importance_score: 1,
+        created_at: new Date(now - 60 * 60 * 1000).toISOString(),
+        updated_at: new Date(now - 60 * 60 * 1000).toISOString(),
+      },
+      {
+        id: '2',
+        title: 'Old',
+        url: 'http://b',
+        source: 'test',
+        published_date: new Date(now - 48 * 60 * 60 * 1000).toISOString(),
+        language: 'en',
+        importance_score: 1,
+        created_at: new Date(now - 48 * 60 * 60 * 1000).toISOString(),
+        updated_at: new Date(now - 48 * 60 * 60 * 1000).toISOString(),
+      },
+    ];
+
+    const builder: any = {
+      select: jest.fn(() => builder),
+      eq: jest.fn(() => builder),
+      gte: jest.fn((field: string, value: string) => {
+        builder._gteValue = value;
+        return builder;
+      }),
+      order: jest.fn(() => builder),
+      limit: jest.fn(async () => {
+        const since = new Date(builder._gteValue);
+        return {
+          data: articles.filter(a => new Date(a.published_date) >= since),
+          error: null,
+        };
+      }),
+    };
+
+    const client: any = { from: jest.fn(() => builder) };
+    (createClient as jest.Mock).mockReturnValue(client);
+
+    const result = await getLatestNews('en');
+
+    expect(builder.gte).toHaveBeenCalled();
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('1');
+  });
+});
+

--- a/src/lib/news/fetcher.ts
+++ b/src/lib/news/fetcher.ts
@@ -268,6 +268,9 @@ export async function fetchAndStoreNews(language: 'en' | 'ja' = 'en'): Promise<N
 
 export async function getLatestNews(language: 'en' | 'ja' = 'en'): Promise<NewsItem[]> {
   const supabase = getSupabaseClient();
+  const env = validateEnv();
+  const lookbackMs = env.newsLookbackHours * 60 * 60 * 1000;
+  const since = new Date(Date.now() - lookbackMs).toISOString();
   const articleService = new ArticleService();
   console.log('Getting latest news from database:', language);
 
@@ -277,6 +280,7 @@ export async function getLatestNews(language: 'en' | 'ja' = 'en'): Promise<NewsI
       .from('news_items')
       .select('*')
       .eq('language', language)
+      .gte('published_date', since)
       .order('importance_score', { ascending: false })
       .limit(10); // Limit to top 10 articles
 
@@ -308,6 +312,7 @@ export async function getLatestNews(language: 'en' | 'ja' = 'en'): Promise<NewsI
         .from('news_items')
         .select('*')
         .eq('language', language)
+        .gte('published_date', since)
         .order('importance_score', { ascending: false })
         .limit(10);
 


### PR DESCRIPTION
## Summary
- add `NEWS_LOOKBACK_HOURS` env support
- filter latest news by `published_date`
- add missing service role key to Jest setup
- test filtering of recent news articles

## Testing
- `npx jest src/lib/news/fetcher.test.ts`
- `npx jest`