### PR TITLE
Add summary translation services

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,20 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Environment Variables
+
+The application requires the following environment variables:
+
+```
+NEXT_PUBLIC_SUPABASE_URL
+NEXT_PUBLIC_SUPABASE_ANON_KEY
+SUPABASE_SERVICE_ROLE_KEY
+
+PERPLEXITY_API_URL
+PERPLEXITY_API_KEY
+TRANSLATION_API_URL
+TRANSLATION_API_KEY
+```
+
+`PERPLEXITY_API_URL` and `PERPLEXITY_API_KEY` configure the Perplexity API used to generate article summaries. `TRANSLATION_API_URL` and `TRANSLATION_API_KEY` configure the translation service for converting summaries into Japanese when necessary.

--- a/src/lib/config/env.ts
+++ b/src/lib/config/env.ts
@@ -9,7 +9,11 @@ export function validateEnv() {
   const required = [
     'NEXT_PUBLIC_SUPABASE_URL',
     'NEXT_PUBLIC_SUPABASE_ANON_KEY',
-    'SUPABASE_SERVICE_ROLE_KEY'
+    'SUPABASE_SERVICE_ROLE_KEY',
+    'PERPLEXITY_API_URL',
+    'PERPLEXITY_API_KEY',
+    'TRANSLATION_API_URL',
+    'TRANSLATION_API_KEY'
   ];
 
   const missing = required.filter(key => 
@@ -28,6 +32,14 @@ export function validateEnv() {
       url: process.env.NEXT_PUBLIC_SUPABASE_URL as string,
       anonKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string,
       serviceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY as string
+    },
+    perplexity: {
+      url: process.env.PERPLEXITY_API_URL as string,
+      apiKey: process.env.PERPLEXITY_API_KEY as string
+    },
+    translation: {
+      url: process.env.TRANSLATION_API_URL as string,
+      apiKey: process.env.TRANSLATION_API_KEY as string
     }
   };
 }

--- a/src/lib/services/perplexityService.ts
+++ b/src/lib/services/perplexityService.ts
@@ -1,0 +1,31 @@
+import { validateEnv } from '../config/env';
+
+export class PerplexityService {
+  private apiUrl: string;
+  private apiKey: string;
+
+  constructor() {
+    const env = validateEnv();
+    this.apiUrl = env.perplexity.url;
+    this.apiKey = env.perplexity.apiKey;
+  }
+
+  public async summarize(url: string, language: string = 'ja'): Promise<string> {
+    const response = await fetch(this.apiUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({ url, language }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Perplexity API error: ${response.status} ${errorText}`);
+    }
+
+    const data = await response.json();
+    return data.summary || '';
+  }
+}

--- a/src/lib/services/translationService.ts
+++ b/src/lib/services/translationService.ts
@@ -1,0 +1,31 @@
+import { validateEnv } from '../config/env';
+
+export class TranslationService {
+  private apiUrl: string;
+  private apiKey: string;
+
+  constructor() {
+    const env = validateEnv();
+    this.apiUrl = env.translation.url;
+    this.apiKey = env.translation.apiKey;
+  }
+
+  public async translate(text: string, targetLang: string): Promise<string> {
+    const response = await fetch(this.apiUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({ text, targetLang }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Translation API error: ${response.status} ${errorText}`);
+    }
+
+    const data = await response.json();
+    return data.translatedText || data.translation || '';
+  }
+}


### PR DESCRIPTION
## Summary
- add TranslationService and PerplexityService wrappers
- extend env configuration with API details
- fetch Japanese summaries and translate if needed
- document new environment variables

## Testing
- `npm run typecheck`