### PR TITLE
Remove Supabase auto connection test

### DIFF
--- a/src/app/api/news/clear/route.ts
+++ b/src/app/api/news/clear/route.ts
@@ -1,13 +1,10 @@
 import { NextResponse } from 'next/server';
-import { validateEnv } from '@/lib/config/env';
-import { createClient } from '@supabase/supabase-js';
+import { supabase } from '@/lib/supabase';
 
 export const dynamic = 'force-dynamic';
 
 export async function POST() {
   try {
-    const env = validateEnv();
-    const supabase = createClient(env.supabase.url, env.supabase.serviceRoleKey);
 
     // Delete all news items
     const { error } = await supabase

--- a/src/lib/news/fetcher.ts
+++ b/src/lib/news/fetcher.ts
@@ -1,13 +1,7 @@
 // src/lib/news/fetcher.ts
 import { NewsItem, NEWS_SOURCES } from '@/types/news';
-import { validateEnv } from '../config/env';
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { supabase } from '../supabase';
 import { ArticleService } from '../services/articleService';
-
-function getSupabaseClient(): SupabaseClient {
-  const env = validateEnv();
-  return createClient(env.supabase.url, env.supabase.serviceRoleKey);
-}
 
 async function fetchRSSWithProxy(url: string): Promise<any[]> {
   console.log('Fetching RSS with proxy:', url);
@@ -188,7 +182,6 @@ function isTechnicalContent(text: string, isJapanese: boolean = false): boolean 
 }
 
 export async function fetchAndStoreNews(language: 'en' | 'ja' = 'en'): Promise<NewsItem[]> {
-  const supabase = getSupabaseClient();
   const sources = NEWS_SOURCES.filter(source => source.language === language);
   const allItems: NewsItem[] = [];
   const articleService = new ArticleService();
@@ -267,7 +260,6 @@ export async function fetchAndStoreNews(language: 'en' | 'ja' = 'en'): Promise<N
 }
 
 export async function getLatestNews(language: 'en' | 'ja' = 'en'): Promise<NewsItem[]> {
-  const supabase = getSupabaseClient();
   const articleService = new ArticleService();
   console.log('Getting latest news from database:', language);
 

--- a/src/lib/services/articleService.ts
+++ b/src/lib/services/articleService.ts
@@ -1,7 +1,6 @@
 // src/lib/services/articleService.ts
 import { NewsItem } from '@/types/news';
-import { createClient } from '@supabase/supabase-js';
-import { validateEnv } from '../config/env';
+import { supabase } from '../supabase';
 
 export class ArticleService {
   private keywordWeights: Record<string, number> = {
@@ -295,8 +294,6 @@ export class ArticleService {
   }
 
   public async updateArticleScores(): Promise<void> {
-    const env = validateEnv();
-    const supabase = createClient(env.supabase.url, env.supabase.serviceRoleKey);
 
     const { data: articles, error } = await supabase
       .from('news_items')
@@ -322,8 +319,6 @@ export class ArticleService {
   }
 
   public async getTopArticles(language: 'en' | 'ja', limit: number = 10): Promise<Array<NewsItem & { score_breakdown?: any }>> {
-    const env = validateEnv();
-    const supabase = createClient(env.supabase.url, env.supabase.serviceRoleKey);
 
     const { data: articles, error } = await supabase
       .from('news_items')

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -16,12 +16,12 @@ export const supabase = createClient<Database>(
   }
 );
 
-// Test the connection
-void (async () => {
+export async function testConnection(): Promise<void> {
   try {
     await supabase.from('news_items').select('count');
     console.log('Supabase: Connection successful');
   } catch (err) {
     console.error('Supabase: Connection error:', err);
+    throw err;
   }
-})();
+}


### PR DESCRIPTION
## Summary
- expose a `testConnection` helper instead of testing on import
- use shared Supabase client across modules
- simplify clear route

## Testing
- `npm run typecheck`
- `npm run lint`
